### PR TITLE
chore: Schedule page generation every 10 minutes

### DIFF
--- a/.github/workflows/generate-pages-from-docker.yml
+++ b/.github/workflows/generate-pages-from-docker.yml
@@ -1,10 +1,8 @@
 name: Generate pages from Docker proxy and publish to GitHub Pages
 
 on:
-  workflow_dispatch:
-  push:
-    branches:
-      - main
+  schedule:
+    - cron: '*/10 * * * *'
 
 permissions:
   contents: write


### PR DESCRIPTION
The workflow `generate-pages-from-docker.yml` is now triggered on a schedule every 10 minutes instead of on push to the main branch or workflow dispatch.