### PR TITLE
feat: Add repository_dispatch trigger and update cron schedule

### DIFF
--- a/.github/workflows/generate-pages-from-docker.yml
+++ b/.github/workflows/generate-pages-from-docker.yml
@@ -1,9 +1,11 @@
 name: Generate pages from Docker proxy and publish to GitHub Pages
 
 on:
-  workflow_dispatch:
   schedule:
-    - cron: '*/10 * * * *'
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+  repository_dispatch:
+    types: [ external_trigger ]
 
 permissions:
   contents: write


### PR DESCRIPTION
The workflow trigger is updated to include `repository_dispatch` for external triggers. The scheduled cron job is adjusted to run every 15 minutes instead of every 10 minutes.