### PR TITLE
refactor: Simplify links.json and configure user for GitHub Actions

### DIFF
--- a/.github/workflows/generate-pages-from-docker.yml
+++ b/.github/workflows/generate-pages-from-docker.yml
@@ -111,3 +111,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public
+          user_name: "github-actions[bot]"
+          user_email: "noreply+gh-actions@users.noreply.github.com"

--- a/docs/links.json
+++ b/docs/links.json
@@ -1,22 +1,5 @@
-{
-  "name": "news-extraction-api",
-  "version": "1",
-  "links": [
-    {
-      "id": "cloudflare-bypass",
-      "url": "http://cloudflare.bnhze9dzfvf5b8gs.switzerlandnorth.azurecontainer.io:8000/html"
-    },
-    {
-      "id": "news-en",
-      "url": "https://visas-it.tlscontact.com/en-us/country/by/vac/byMSQ2it/news"
-    },
-    {
-      "id": "news-ru",
-      "url": "https://visas-it.tlscontact.com/ru-ru/country/by/vac/byMSQ2it/news"
-    },
-    {
-      "id": "news-it",
-      "url": "https://visas-it.tlscontact.com/it-it/country/by/vac/byMSQ2it/news"
-    }
-  ]
-}
+[
+  "en-us.html",
+  "it-it.html",
+  "ru-ru.html"
+]


### PR DESCRIPTION
This commit refactors the `docs/links.json` file to a simple array of HTML filenames, removing the previous JSON object structure. Additionally, it configures the user name and e-mail for the `generate-pages-from-docker.yml` GitHub Actions workflow.